### PR TITLE
Use `truncated` instead of `Truncated`

### DIFF
--- a/benchmarks/ParameterEstimation/DiffEqBayesFitzHughNagumo.jmd
+++ b/benchmarks/ParameterEstimation/DiffEqBayesFitzHughNagumo.jmd
@@ -51,7 +51,7 @@ plot!(sol)
 ### Priors for the parameters which will be passed for the Bayesian Inference
 
 ```julia
-priors = [Truncated(Normal(1.0,0.5),0,1.5),Truncated(Normal(1.0,0.5),0,1.5),Truncated(Normal(0.0,0.5),0.0,0.5),Truncated(Normal(0.5,0.5),0,1)]
+priors = [truncated(Normal(1.0,0.5),0,1.5),truncated(Normal(1.0,0.5),0,1.5),truncated(Normal(0.0,0.5),0.0,0.5),truncated(Normal(0.5,0.5),0,1)]
 ```
 
 ### Benchmarks

--- a/benchmarks/ParameterEstimation/DiffEqBayesLorenz.jmd
+++ b/benchmarks/ParameterEstimation/DiffEqBayesLorenz.jmd
@@ -78,12 +78,12 @@ plot(sim,vars=(0,1),linealpha=0.4)
 ```
 
 ```julia
-priors = [Truncated(Normal(10,2),1,15),Truncated(Normal(30,5),1,45),Truncated(Normal(2.5,0.5),1,4)]
+priors = [truncated(Normal(10,2),1,15),truncated(Normal(30,5),1,45),truncated(Normal(2.5,0.5),1,4)]
 ```
 
 ## Using Stan.jl backend.
 
-Lorenz equation is a chaotic system hence requires very low tolerance to be estimated in a reasonable way, we use 1e-8 obtained from the uncertainity plots. Use of Truncated priors is necessary to prevent Stan from stepping into negative and other improbable areas.
+Lorenz equation is a chaotic system hence requires very low tolerance to be estimated in a reasonable way, we use 1e-8 obtained from the uncertainity plots. Use of truncated priors is necessary to prevent Stan from stepping into negative and other improbable areas.
 
 ```julia
 #@time bayesian_result_stan = stan_inference(prob,t,data,priors;reltol=1e-8,abstol=1e-8)

--- a/benchmarks/ParameterEstimation/DiffEqBayesLotkaVolterra.jmd
+++ b/benchmarks/ParameterEstimation/DiffEqBayesLotkaVolterra.jmd
@@ -56,7 +56,7 @@ plot!(sol)
 ```
 
 ```julia
-priors = [Truncated(Normal(1.5,0.5),0.5,2.5),Truncated(Normal(1.2,0.5),0,2),Truncated(Normal(3.0,0.5),1,4),Truncated(Normal(1.0,0.5),0,2)]
+priors = [truncated(Normal(1.5,0.5),0.5,2.5),truncated(Normal(1.2,0.5),0,2),truncated(Normal(3.0,0.5),1,4),truncated(Normal(1.0,0.5),0,2)]
 ```
 
 ### Stan.jl backend


### PR DESCRIPTION
Just noticed that DiffEqBenchmarks uses the deprecated `Truncated` instead of `truncated` which (potentially) creates optimized truncated distributions and uses `Truncated` as fallback. I remember some simple models in Turing being quite slow due to deprecation warnings, so probably better to use `truncated` in the benchmarks.

I'm not sure what's the correct procedure for rerunning and regenerating the different output formats?