### PR TITLE
Rebuild benchmarks

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,7 +1,7 @@
 name: TagBot
 on:
   schedule:
-    - cron: 0 * * * *
+    - cron: 0 0 * * *
 jobs:
   TagBot:
     runs-on: ubuntu-latest

--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -1,0 +1,76 @@
+name: Rebuild Content
+on:
+  schedule:
+    - cron: 0 0 */3 * *
+  issue_comment:
+    types:
+      - created
+  push:
+  status:
+env:
+  GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
+  GITLAB_TRIGGER: https://gitlab.com/api/v4/projects/${{ secrets.GITLAB_PROJECT }}/trigger/pipeline
+jobs:
+  RandomRebuild:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          curl --fail \
+            -F "token=$GITLAB_TOKEN" \
+            -F "ref=master" \
+            "$GITLAB_TRIGGER"
+  ManualRebuild:
+    if: github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '!rebuild')
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          arg="$(echo '${{ github.event.comment.body }}' | head -n1 | cut -d' ' -f2)"
+          folder="$(echo $arg | cut -d/ -f1)"
+          file="$(echo $arg | cut -d/ -f2)"
+          curl --fail \
+            -F "token=$GITLAB_TOKEN" \
+            -F "ref=master" \
+            -F "variables[FOLDER]=$folder" \
+            -F "variables[FILE]=$file" \
+            "$GITLAB_TRIGGER"
+      - uses: actions/github-script@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.reactions.createForIssueComment({
+              ...context.repo,
+              comment_id: context.payload.comment.id,
+              content: "+1",
+            })
+  OpenPR:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/rebuild/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.pulls.create({
+              ...context.repo,
+              title: "Rebuild content,
+              head: "${{ github.ref }}".slice(11),
+              base: "master",
+            })
+  FixStatus:
+    if: github.event_name == 'status' && github.event.context == 'ci/gitlab/gitlab.com' && github.event.state == 'failure'
+    runs-on: ubuntu-latest
+    steps:
+      # TODO: Replace this SHA with a tag when the next version is released.
+      - uses: actions/github-script@82b33c82ef5e155cb8e0de0862e5dbde0cd451eb
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.repos.createCommitStatus({
+              ...context.repo,
+              sha: context.payload.sha,
+              state: "success",
+              context: context.payload.context,
+              description: "This status can be ignored",
+              target_url: context.payload.target_url,
+            })

--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -6,71 +6,13 @@ on:
     types:
       - created
   push:
-  status:
 env:
+  GITLAB_PROJECT: ${{ secrets.GITLAB_PROJECT }}
   GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
-  GITLAB_TRIGGER: https://gitlab.com/api/v4/projects/${{ secrets.GITLAB_PROJECT }}/trigger/pipeline
 jobs:
-  RandomRebuild:
-    if: github.event_name == 'schedule'
+  Rebuild:
     runs-on: ubuntu-latest
     steps:
-      - run: |
-          curl --fail \
-            -F "token=$GITLAB_TOKEN" \
-            -F "ref=master" \
-            "$GITLAB_TRIGGER"
-  ManualRebuild:
-    if: github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '!rebuild')
-    runs-on: ubuntu-latest
-    steps:
-      - run: |
-          arg="$(echo '${{ github.event.comment.body }}' | head -n1 | cut -d' ' -f2)"
-          folder="$(echo $arg | cut -d/ -f1)"
-          file="$(echo $arg | cut -d/ -f2)"
-          curl --fail \
-            -F "token=$GITLAB_TOKEN" \
-            -F "ref=master" \
-            -F "variables[FOLDER]=$folder" \
-            -F "variables[FILE]=$file" \
-            "$GITLAB_TRIGGER"
-      - uses: actions/github-script@v2
+      - uses: SciML/RebuildAction@master
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            github.reactions.createForIssueComment({
-              ...context.repo,
-              comment_id: context.payload.comment.id,
-              content: "+1",
-            })
-  OpenPR:
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/rebuild/')
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/github-script@v2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            github.pulls.create({
-              ...context.repo,
-              title: "Rebuild content,
-              head: "${{ github.ref }}".slice(11),
-              base: "master",
-            })
-  FixStatus:
-    if: github.event_name == 'status' && github.event.context == 'ci/gitlab/gitlab.com' && github.event.state == 'failure'
-    runs-on: ubuntu-latest
-    steps:
-      # TODO: Replace this SHA with a tag when the next version is released.
-      - uses: actions/github-script@82b33c82ef5e155cb8e0de0862e5dbde0cd451eb
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            github.repos.createCommitStatus({
-              ...context.repo,
-              sha: context.payload.sha,
-              state: "success",
-              context: context.payload.context,
-              description: "This status can be ignored",
-              target_url: context.payload.target_url,
-            })
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 tmp*/
 gks.svg
 Manifest.toml
+/*/*/jl_*/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,4 @@
+include: https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/cdg/rebuilds/templates/rebuild/v1.yml
+variables:
+  CONTENT_DIR: benchmarks
+  GITHUB_REPOSITORY: SciML/DiffEqBenchmarks.jl

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,6 @@
-include: https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/cdg/rebuilds/templates/rebuild/v1.yml
+include: https://raw.githubusercontent.com/SciML/RebuildAction/master/rebuild.yml
 variables:
   CONTENT_DIR: benchmarks
   GITHUB_REPOSITORY: SciML/DiffEqBenchmarks.jl
+  GPU_TAG: nvidia-benchmark
+  TAGS: nvidia-benchmark


### PR DESCRIPTION
This is dependent on https://github.com/JuliaGPU/gitlab-ci/pull/22

Basically the same thing as the tutorials.

TODO:
- Figure out which runner tag should be used for benchmark jobs
- Change a path from `cdg/rebuilds` to `master` in `.gitlab-ci.yml` when the JuliaGPU/gitlab-ci PR is merged

Here's a commit it made: https://github.com/SciML/DiffEqBenchmarks.jl/commit/c211b96ea685bc122e865eb45458f0d63fd4af87